### PR TITLE
Allow multiple env keys

### DIFF
--- a/lib/MooX/Attribute/ENV.pm
+++ b/lib/MooX/Attribute/ENV.pm
@@ -98,6 +98,11 @@ MooX::Attribute::ENV - Allow Moo attributes to get their values from %ENV
     is => 'ro',
     env_key => 'attr_val',
   );
+  # look for $ENV{attr_val} and $ENV{next_VAL}, in that order
+  has some => (
+    is => 'ro',
+    env_key => [ 'attr_val', 'next_val' ],
+  );
   # looks for $ENV{otherattr} and $ENV{OTHERATTR}, then any default
   has otherattr => (
     is => 'ro',
@@ -144,6 +149,10 @@ Boolean. If true, the name is the attribute, no prefix.
 =head2 env_key
 
 String. If true, the name is the given value, no prefix.
+
+or
+
+ArrayRef. A list of names that will be checked in given order.
 
 =head2 env_prefix
 

--- a/lib/MooX/Attribute/ENV.pm
+++ b/lib/MooX/Attribute/ENV.pm
@@ -44,9 +44,11 @@ sub import {
 }
 
 sub _lookup_env {
-  my ($envkey) = @_;
-  return $ENV{$envkey} if exists $ENV{$envkey};
-  return $ENV{uc $envkey} if exists $ENV{uc $envkey};
+  my @env_keys = ref $_[0] eq 'ARRAY' ? @{ $_[0] } : $_[0];
+  foreach my $envkey ( @env_keys ) {
+      return $ENV{$envkey} if exists $ENV{$envkey};
+      return $ENV{uc $envkey} if exists $ENV{uc $envkey};
+  }
   undef;
 }
 

--- a/t/multi_key.t
+++ b/t/multi_key.t
@@ -1,0 +1,32 @@
+use Test::More;
+
+package MyMod;
+use Moo;
+use MooX::Attribute::ENV;
+# look for $ENV{attr_val} and $ENV{ATTR_VAL}
+has attr => (
+  is => 'ro',
+  env_key => [ 'attr_val', 'next_val' ],
+);
+# looks for $ENV{otherattr} and $ENV{OTHERATTR}, then any default
+
+package main;
+
+sub test_with_env {
+  my ($attr, $env, $expected) = @_;
+  local %ENV = (%ENV, %$env);
+  my $obj = MyMod->new;
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
+  is $obj->$attr, $expected, "$attr from ENV(@{[ keys %$env ]})";
+}
+
+test_with_env(attr => { ATTR_VAL => 1 }, 1);
+test_with_env(attr => { attr_val => 2 }, 2);
+
+test_with_env(attr => { ATTR_VAL => 1, NEXT_VAL => 3 }, 1);
+test_with_env(attr => { attr_val => 2, next_val => 4 }, 2);
+
+test_with_env(attr => { NEXT_VAL => 3 }, 3);
+test_with_env(attr => { next_val => 4 }, 4);
+
+done_testing;


### PR DESCRIPTION
Hi Ed,

Please consider this MR and have it merged.

I did not update CHANGES nor the $VERION, or set the tag to 0.03

Have fun

this fixes https://github.com/mohawk2/moox-attribute-env/issues/2